### PR TITLE
Fix missing semicolon in DetermineOutputPath

### DIFF
--- a/razorlame/Main.pas
+++ b/razorlame/Main.pas
@@ -2095,7 +2095,7 @@ begin
   Result := asInputFilePath;
   if MP3Settings.UseInputDir then exit;
   if (Trim(MP3Settings.OutDir) <> '') and DirectoryExists(MP3Settings.OutDir) then
-    Result := MP3Settings.OutDir
+    Result := MP3Settings.OutDir;
 end;
 
 procedure TFormMain.ListViewFilesDblClick(Sender: TObject);


### PR DESCRIPTION
## Summary
- fix missing semicolon in `DetermineOutputPath`

## Testing
- `fpc` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_683f41bacae8832da9ebe1034265f38e