### PR TITLE
Fix typos in RazorLame comments

### DIFF
--- a/razorlame/Main.pas
+++ b/razorlame/Main.pas
@@ -897,7 +897,7 @@ begin
   finally
     MyFileList.Free;
   end;
-  //-- erase the old ini section; compatability stuff, see comment under "LoadFileList"
+  //-- erase the old ini section; compatibility stuff, see comment under "LoadFileList"
   with TIniFile.Create(ChangeFileExt(LowerCase(Application.ExeName), '.ini')) do
   try
     //-- First erase the entire section

--- a/razorlame/UtilFuncs.pas
+++ b/razorlame/UtilFuncs.pas
@@ -613,7 +613,7 @@ function GetFileSize(const FileName: string): Int64;
 var
   SearchRec: TSearchRec;
 begin
-  Result := -1; //-- assume worst cas
+  Result := -1; //-- assume worst case
   if FindFirst(FileName, faAnyFile, SearchRec) = 0 then
   begin
     //Result := SearchRec.Size;

--- a/razorlame/progress.pas
+++ b/razorlame/progress.pas
@@ -316,7 +316,7 @@ var
   var
     x, y, x2, y2, liTextWidth: Integer;
   begin
-    //-- claculate upper left point of bar
+    //-- calculate upper left point of bar
     x := Round(lfWidth * liBar);
     y := liHeight - Round(liHeight * ((liMSValue + liSSValue) / liMax));
     y2 := y;


### PR DESCRIPTION
## Summary
- fix a typo for backward compatibility note in `Main.pas`
- fix a comment typo in `progress.pas`
- fix a comment typo in `UtilFuncs.pas`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683f474cc110832dabff127c08032dd2