### PR TITLE
Fix incorrect comparison in Redirector

### DIFF
--- a/razorlame/Redirect.pas
+++ b/razorlame/Redirect.pas
@@ -307,10 +307,9 @@ end;
 
 procedure TRedirector.SetStartSuspended(Value: Boolean);
 begin
-  if (Value = DefaultErrorMode) or not Running then
+  if (Value = FStartSuspended) or not Running then
     FStartSuspended := Value
   else if Running then
-
     Error('Cannot change StartSuspended while process is active');
 end;
 


### PR DESCRIPTION
## Summary
- fix a copy/paste bug in `TRedirector.SetStartSuspended`

## Testing
- `fpc -v0 razorlame/Redirect.pas` *(fails: Can't find unit Windows)*

------
https://chatgpt.com/codex/tasks/task_e_6840923f6a98832db4ea6020d19dd87a