### PR TITLE
Fix typo in error message

### DIFF
--- a/razorlame/Redirect.pas
+++ b/razorlame/Redirect.pas
@@ -319,7 +319,7 @@ begin
     FInitialPriority := Value
   else if Running then
 
-    Error('Cannot change InititalPriority while process is active');
+    Error('Cannot change InitialPriority while process is active');
 end;
 
 procedure TRedirector.SetDirectory(Value: string);


### PR DESCRIPTION
## Summary
- fix misspelled `InitialPriority` in Redirector

## Testing
- `fpc tests/TestDetermineOutputPath.pas`
- `./tests/TestDetermineOutputPath`


------
https://chatgpt.com/codex/tasks/task_e_68415e978e7c832dbb7a84dc6cb994dc