### PR TITLE
Fix typo in comment

### DIFF
--- a/razorlame/UtilFuncs.pas
+++ b/razorlame/UtilFuncs.pas
@@ -652,7 +652,7 @@ end;
 function DeleteZeroByteFile(const FileName: string): Boolean;
 begin
   Result := false;
-  //-- delete's FileName if it's size is 0!
+  //-- deletes FileName if its size is 0!
   if FileExists(FileName) and (GetFileSize(FileName) = 0) then
     Result := DeleteFile(FileName);
 end;


### PR DESCRIPTION
## Summary
- fix grammar in DeleteZeroByteFile comment

## Testing
- `fpc tests/TestDetermineOutputPath.pas`
- `./TestDetermineOutputPath`


------
https://chatgpt.com/codex/tasks/task_e_68415e9ce61c832db8f4abc1d9dd0fff