### PR TITLE
Add missing output path tests

### DIFF
--- a/tests/TestDetermineOutputPath.pas
+++ b/tests/TestDetermineOutputPath.pas
@@ -33,6 +33,8 @@ type
   published
     procedure TestUseInputDirTrue;
     procedure TestUseInputDirFalseOutDirExists;
+    procedure TestUseInputDirFalseOutDirMissing;
+    procedure TestUseInputDirFalseOutDirEmpty;
   end;
 
 procedure TDetermineOutputPathTests.TestUseInputDirTrue;
@@ -62,6 +64,31 @@ begin
   finally
     RemoveDir(OutDir);
   end;
+end;
+
+procedure TDetermineOutputPathTests.TestUseInputDirFalseOutDirMissing;
+var
+  InputPath, OutDir, ResultPath: string;
+begin
+  OutDir := GetTempDir + 'razorlame_missing_outdir';
+  if DirectoryExists(OutDir) then
+    RemoveDir(OutDir);
+  MP3Settings.UseInputDir := False;
+  MP3Settings.OutDir := OutDir;
+  InputPath := '/tmp/somewhere';
+  ResultPath := DetermineOutputPath(InputPath);
+  AssertEquals(InputPath, ResultPath);
+end;
+
+procedure TDetermineOutputPathTests.TestUseInputDirFalseOutDirEmpty;
+var
+  InputPath, ResultPath: string;
+begin
+  MP3Settings.UseInputDir := False;
+  MP3Settings.OutDir := '';
+  InputPath := '/tmp/somewhere';
+  ResultPath := DetermineOutputPath(InputPath);
+  AssertEquals(InputPath, ResultPath);
 end;
 
 begin


### PR DESCRIPTION
## Summary
- extend the DetermineOutputPath test case with two additional scenarios
- keep registration of the full class so the new tests run

## Testing
- `fpc tests/TestDetermineOutputPath.pas`
- `./tests/TestDetermineOutputPath`

------
https://chatgpt.com/codex/tasks/task_e_68415e9f7fcc832db207ab570a43c4a9